### PR TITLE
Make Python API consistent with Scala API with pretty docstring

### DIFF
--- a/python/pyspark/ml/image.py
+++ b/python/pyspark/ml/image.py
@@ -72,7 +72,7 @@ class _ImageSchema(object):
 
         if self._ocvTypes is None:
             ctx = SparkContext._active_spark_context
-            self._ocvTypes = ctx._jvm.org.apache.spark.ml.image.ImageSchema._ocvTypes()
+            self._ocvTypes = dict(ctx._jvm.org.apache.spark.ml.image.ImageSchema._ocvTypes())
         return self._ocvTypes
 
     @property
@@ -108,7 +108,7 @@ class _ImageSchema(object):
         """
         Converts an image to a one-dimensional array.
 
-        :param image (object): The image to be converted
+        :param image: The image to be converted
         :rtype array: The image as a one-dimensional array
 
         .. versionadded:: 2.3.0
@@ -126,8 +126,8 @@ class _ImageSchema(object):
         """
         Converts a one-dimensional array to a two-dimensional image.
 
-        :param array (array): The array to convert to image
-        :param origin (str): Path to the image
+        :param array array: The array to convert to image
+        :param str origin: Path to the image
         :rtype object: Two dimensional image
 
         .. versionadded:: 2.3.0
@@ -148,7 +148,7 @@ class _ImageSchema(object):
         # Creating new Row with _create_row(), because Row(name = value, ... )
         # orders fields by name, which conflicts with expected schema order
         # when the new DataFrame is created by UDF
-        return _create_row(imageFields,
+        return _create_row(self.imageFields,
                            [origin, height, width, nChannels, mode, data])
 
     def readImages(self, path, recursive=False, numPartitions=0,
@@ -156,12 +156,12 @@ class _ImageSchema(object):
         """
         Reads the directory of images from the local or remote source.
 
-        :param path (str): Path to the image directory
-        :param spark (SparkSession): The current spark session
-        :param recursive (bool): Recursive search flag
-        :param numPartitions (int): Number of DataFrame partitions
-        :param dropImageFailures (bool): Drop the files that are not valid images
-        :param sampleRatio (double): Fraction of the images loaded
+        :param str path: Path to the image directory
+        :param SparkSession spark: The current spark session
+        :param bool recursive: Recursive search flag
+        :param int numPartitions: Number of DataFrame partitions
+        :param bool dropImageFailures: Drop the files that are not valid images
+        :param float sampleRatio: Fraction of the images loaded
         :rtype DataFrame: DataFrame with a single column of "images",
                see ImageSchema for details
 

--- a/python/pyspark/ml/image.py
+++ b/python/pyspark/ml/image.py
@@ -15,121 +15,175 @@
 # limitations under the License.
 #
 
+"""
+.. attribute:: ImageSchema
+
+    A singleton-like attribute of :class:`_ImageSchema` in this module.
+
+.. autoclass:: _ImageSchema
+   :members:
+"""
+
 from pyspark import SparkContext
 from pyspark.sql.types import Row, _create_row, _parse_datatype_json_string
 from pyspark.sql import DataFrame, SparkSession
 import numpy as np
 
-undefinedImageType = "Undefined"
-
-imageFields = ["origin", "height", "width", "nChannels", "mode", "data"]
-
 
 class _ImageSchema(object):
     """
-    Returns the image schema.
-
-    :rtype StructType: a DataFrame with a single column of images
-           named "image" (nullable)
-
-    .. versionadded:: 2.3.0
+    Internal class for `pyspark.ml.image.ImageSchema` attribute. Meant to be private and
+    not to be instantized. Use `pyspark.ml.image.ImageSchema` attribute to access the
+    APIs of this class.
     """
+
+    def __init__(self):
+        self._imageSchema = None
+        self._ocvTypes = None
+        self._imageFields = None
+        self._undefinedImageType = None
+
     @property
     def imageSchema(self):
-        ctx = SparkContext._active_spark_context
-        jschema = ctx._jvm.org.apache.spark.ml.image.ImageSchema.imageSchema()
-        return _parse_datatype_json_string(jschema.json())
+        """
+        Returns the image schema.
 
-    """
-    Returns the OpenCV type mapping supported
+        :rtype StructType: a DataFrame with a single column of images
+               named "image" (nullable)
 
-    :rtype dict: The OpenCV type mapping supported
+        .. versionadded:: 2.3.0
+        """
 
-    .. versionadded:: 2.3.0
-    """
+        if self._imageSchema is None:
+            ctx = SparkContext._active_spark_context
+            jschema = ctx._jvm.org.apache.spark.ml.image.ImageSchema.imageSchema()
+            self._imageSchema = _parse_datatype_json_string(jschema.json())
+        return self._imageSchema
+
     @property
     def ocvTypes(self):
+        """
+        Returns the OpenCV type mapping supported
+
+        :rtype dict: The OpenCV type mapping supported
+
+        .. versionadded:: 2.3.0
+        """
+
+        if self._ocvTypes is None:
+            ctx = SparkContext._active_spark_context
+            self._ocvTypes = ctx._jvm.org.apache.spark.ml.image.ImageSchema._ocvTypes()
+        return self._ocvTypes
+
+    @property
+    def imageFields(self):
+        """
+        Returns field names of image columns.
+
+        :rtype list: a list of field names.
+
+        .. versionadded:: 2.3.0
+        """
+
+        if self._imageFields is None:
+            ctx = SparkContext._active_spark_context
+            self._imageFields = list(ctx._jvm.org.apache.spark.ml.image.ImageSchema.imageFields())
+        return self._imageFields
+
+    @property
+    def undefinedImageType(self):
+        """
+        Returns the name of undefined image type for the invalid image.
+
+        .. versionadded:: 2.3.0
+        """
+
+        if self._undefinedImageType is None:
+            ctx = SparkContext._active_spark_context
+            self._undefinedImageType = \
+                ctx._jvm.org.apache.spark.ml.image.ImageSchema.undefinedImageType()
+        return self._undefinedImageType
+
+    def toNDArray(self, image):
+        """
+        Converts an image to a one-dimensional array.
+
+        :param image (object): The image to be converted
+        :rtype array: The image as a one-dimensional array
+
+        .. versionadded:: 2.3.0
+        """
+        height = image.height
+        width = image.width
+        nChannels = image.nChannels
+        return np.ndarray(
+            shape=(height, width, nChannels),
+            dtype=np.uint8,
+            buffer=image.data,
+            strides=(width * nChannels, nChannels, 1))
+
+    def toImage(self, array, origin=""):
+        """
+        Converts a one-dimensional array to a two-dimensional image.
+
+        :param array (array): The array to convert to image
+        :param origin (str): Path to the image
+        :rtype object: Two dimensional image
+
+        .. versionadded:: 2.3.0
+        """
+        if array.ndim != 3:
+            raise ValueError("Invalid array shape")
+        height, width, nChannels = array.shape
+        ocvTypes = ImageSchema.ocvTypes
+        if nChannels == 1:
+            mode = ocvTypes["CV_8UC1"]
+        elif nChannels == 3:
+            mode = ocvTypes["CV_8UC3"]
+        elif nChannels == 4:
+            mode = ocvTypes["CV_8UC4"]
+        else:
+            raise ValueError("Invalid number of channels")
+        data = bytearray(array.astype(dtype=np.uint8).ravel())
+        # Creating new Row with _create_row(), because Row(name = value, ... )
+        # orders fields by name, which conflicts with expected schema order
+        # when the new DataFrame is created by UDF
+        return _create_row(imageFields,
+                           [origin, height, width, nChannels, mode, data])
+
+    def readImages(self, path, recursive=False, numPartitions=0,
+                   dropImageFailures=False, sampleRatio=1.0):
+        """
+        Reads the directory of images from the local or remote source.
+
+        :param path (str): Path to the image directory
+        :param spark (SparkSession): The current spark session
+        :param recursive (bool): Recursive search flag
+        :param numPartitions (int): Number of DataFrame partitions
+        :param dropImageFailures (bool): Drop the files that are not valid images
+        :param sampleRatio (double): Fraction of the images loaded
+        :rtype DataFrame: DataFrame with a single column of "images",
+               see ImageSchema for details
+
+        >>> df = ImageSchema.readImages('python/test_support/image/kittens', recursive=True)
+        >>> df.count()
+        4
+
+        .. versionadded:: 2.3.0
+        """
         ctx = SparkContext._active_spark_context
-        return ctx._jvm.org.apache.spark.ml.image.ImageSchema._ocvTypes()
+        spark = SparkSession(ctx)
+        image_schema = ctx._jvm.org.apache.spark.ml.image.ImageSchema
+        jsession = spark._jsparkSession
+        jresult = image_schema.readImages(path, jsession, recursive, numPartitions,
+                                          dropImageFailures, float(sampleRatio))
+        return DataFrame(jresult, spark._wrapped)
+
 
 ImageSchema = _ImageSchema()
 
 
-def toNDArray(image):
-    """
-    Converts an image to a one-dimensional array.
-
-    :param image (object): The image to be converted
-    :rtype array: The image as a one-dimensional array
-
-    .. versionadded:: 2.3.0
-    """
-    height = image.height
-    width = image.width
-    nChannels = image.nChannels
-    return np.ndarray(
-        shape=(height, width, nChannels),
-        dtype=np.uint8,
-        buffer=image.data,
-        strides=(width * nChannels, nChannels, 1))
-
-
-def toImage(array, origin=""):
-    """
-    Converts a one-dimensional array to a two-dimensional image.
-
-    :param array (array): The array to convert to image
-    :param origin (str): Path to the image
-    :rtype object: Two dimensional image
-
-    .. versionadded:: 2.3.0
-    """
-    if array.ndim != 3:
-        raise ValueError("Invalid array shape")
-    height, width, nChannels = array.shape
-    ocvTypes = ImageSchema.ocvTypes
-    if nChannels == 1:
-        mode = ocvTypes["CV_8UC1"]
-    elif nChannels == 3:
-        mode = ocvTypes["CV_8UC3"]
-    elif nChannels == 4:
-        mode = ocvTypes["CV_8UC4"]
-    else:
-        raise ValueError("Invalid number of channels")
-    data = bytearray(array.astype(dtype=np.uint8).ravel())
-    # Creating new Row with _create_row(), because Row(name = value, ... )
-    # orders fields by name, which conflicts with expected schema order
-    # when the new DataFrame is created by UDF
-    return _create_row(imageFields,
-                       [origin, height, width, nChannels, mode, data])
-
-
-def readImages(path, recursive=False, numPartitions=0,
-               dropImageFailures=False, sampleRatio=1.0):
-    """
-    Reads the directory of images from the local or remote source.
-
-    :param path (str): Path to the image directory
-    :param spark (SparkSession): The current spark session
-    :param recursive (bool): Recursive search flag
-    :param numPartitions (int): Number of DataFrame partitions
-    :param dropImageFailures (bool): Drop the files that are not valid images
-    :param sampleRatio (double): Fraction of the images loaded
-    :rtype DataFrame: DataFrame with a single column of "images",
-           see ImageSchema for details
-
-    Examples:
-
-    >>> df = readImages('python/test_support/image/kittens', recursive=True)
-    >>> df.count
-    4
-
-    .. versionadded:: 2.3.0
-    """
-    ctx = SparkContext._active_spark_context
-    spark = SparkSession(ctx)
-    image_schema = ctx._jvm.org.apache.spark.ml.image.ImageSchema
-    jsession = spark._jsparkSession
-    jresult = image_schema.readImages(path, jsession, recursive, numPartitions,
-                                      dropImageFailures, float(sampleRatio))
-    return DataFrame(jresult, spark._wrapped)
+# Monkey patch to disallow instantization of this class.
+def _disallow_instance(_):
+    raise RuntimeError("Creating instance of _ImageSchema class is disallowed.")
+_ImageSchema.__init__ = _disallow_instance

--- a/python/pyspark/ml/image.py
+++ b/python/pyspark/ml/image.py
@@ -113,6 +113,7 @@ class _ImageSchema(object):
 
         .. versionadded:: 2.3.0
         """
+
         height = image.height
         width = image.width
         nChannels = image.nChannels
@@ -132,6 +133,7 @@ class _ImageSchema(object):
 
         .. versionadded:: 2.3.0
         """
+
         if array.ndim != 3:
             raise ValueError("Invalid array shape")
         height, width, nChannels = array.shape
@@ -171,6 +173,7 @@ class _ImageSchema(object):
 
         .. versionadded:: 2.3.0
         """
+
         ctx = SparkContext._active_spark_context
         spark = SparkSession(ctx)
         image_schema = ctx._jvm.org.apache.spark.ml.image.ImageSchema

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -54,7 +54,7 @@ from pyspark.ml.evaluation import BinaryClassificationEvaluator, \
     MulticlassClassificationEvaluator, RegressionEvaluator
 from pyspark.ml.feature import *
 from pyspark.ml.fpm import FPGrowth, FPGrowthModel
-from pyspark.ml.image import toImage, toNDArray, readImages, ImageSchema
+from pyspark.ml.image import ImageSchema
 from pyspark.ml.linalg import DenseMatrix, DenseMatrix, DenseVector, Matrices, MatrixUDT, \
     SparseMatrix, SparseVector, Vector, VectorUDT, Vectors
 from pyspark.ml.param import Param, Params, TypeConverters
@@ -1823,13 +1823,18 @@ class ImageReaderTest(SparkSessionTestCase):
 
     def test_read_images(self):
         data_path = 'python/test_support/image/kittens'
-        df = readImages(data_path, recursive=True)
+        df = ImageSchema.readImages(data_path, recursive=True)
         self.assertEqual(df.count(), 4)
-        firstRow = df.take(1)[0][0]
-        array = toNDArray(firstRow)
-        self.assertEqual(len(array), firstRow[1])
-        self.assertEqual(toImage(array, origin=firstRow[0]), firstRow)
+        first_row = df.take(1)[0][0]
+        array = ImageSchema.toNDArray(first_row)
+        self.assertEqual(len(array), first_row[1])
+        self.assertEqual(ImageSchema.toImage(array, origin=first_row[0]), first_row)
         self.assertEqual(df.schema, ImageSchema.imageSchema)
+        expected = {'CV_8UC3': 16, 'Undefined': -1, 'CV_8U': 0, 'CV_8UC1': 0, 'CV_8UC4': 24}
+        self.assertEqual(ImageSchema.ocvTypes, expected)
+        expected = ['origin', 'height', 'width', 'nChannels', 'mode', 'data']
+        self.assertEqual(ImageSchema.imageFields, expected)
+        self.assertEqual(ImageSchema.undefinedImageType, "Undefined")
 
 
 class ALSTest(SparkSessionTestCase):


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR proposes to make Python API consistent with Scala API with pretty docstring.

**1. Now, we can do it similarly with Scala API:**

```python
from pyspark.ml import ImageSchema
ImageSchema.imageSchema
```

**2. This generates Python API doc as below:**

<img width="739" alt="2017-11-02 12 54 09" src="https://user-images.githubusercontent.com/6477701/32284073-6d9c0728-bf69-11e7-8eb5-44be4bc60eba.png">


**3. pydoc (help(...)) seems also acceptable (to me):**

```python
>>> from pyspark.ml.image import ImageSchema
>>> help(ImageSchema)
```

```
Help on _ImageSchema in module pyspark.ml.image object:

class _ImageSchema(__builtin__.object)
 |  Internal class for `pyspark.ml.image.ImageSchema` attribute. Meant to be private and
 |  not to be instantized. Use `pyspark.ml.image.ImageSchema` attribute to access the
 |  APIs of this class.
 |
 |  Methods defined here:
 |
 |  __init__ = _disallow_instance(_)
 |      # Monkey patch to disallow instantization of this class.
 |
 |  readImages(self, path, recursive=False, numPartitions=0, dropImageFailures=False, sampleRatio=1.0)
 |      Reads the directory of images from the local or remote source.
 |
 |      :param str path: Path to the image directory
 |      :param SparkSession spark: The current spark session
 |      :param bool recursive: Recursive search flag
 |      :param int numPartitions: Number of DataFrame partitions
 |      :param bool dropImageFailures: Drop the files that are not valid images
 |      :param float sampleRatio: Fraction of the images loaded
 |      :rtype DataFrame: DataFrame with a single column of "images",
 |             see ImageSchema for details
 |
 |      >>> df = ImageSchema.readImages('python/test_support/image/kittens', recursive=True)
 |      >>> df.count()
 |      4
 |
 |      .. versionadded:: 2.3.0
 |
 |  toImage(self, array, origin='')
 |      Converts a one-dimensional array to a two-dimensional image.
 |
 |      :param array array: The array to convert to image
...
 |  ----------------------------------------------------------------------
 |  Data descriptors defined here:
 |
 ...
 |  imageFields
 |      Returns field names of image columns.
 |
 |      :rtype list: a list of field names.
 |
 |      .. versionadded:: 2.3.0
 |
 |  imageSchema
 |      Returns the image schema.
 |
 |      :rtype StructType: a DataFrame with a single column of images
 |             named "image" (nullable)
 |
 |      .. versionadded:: 2.3.0
 |
 |  ocvTypes
 |      Returns the OpenCV type mapping supported
 |
 |      :rtype dict: The OpenCV type mapping supported
 |
 |      .. versionadded:: 2.3.0
 |
 |  undefinedImageType
 |      Returns the name of undefined image type for the invalid image.
 |
 |      .. versionadded:: 2.3.0
```

**4. Monkey patched to disallow `__init__`:**

```python
>>> from pyspark.ml.image import _ImageSchema
>>> _ImageSchema()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../spark/python/pyspark/ml/image.py", line 191, in _disallow_instance
    raise RuntimeError("Creating instance of _ImageSchema class is disallowed.")
RuntimeError: Creating instance of _ImageSchema class is disallowed.
```

## How was this patch tested?

Manually tested.